### PR TITLE
Fix for parsing names of pod subspecs

### DIFF
--- a/cocoapods/lib/dependabot/cocoapods/file_updater.rb
+++ b/cocoapods/lib/dependabot/cocoapods/file_updater.rb
@@ -9,7 +9,7 @@ module Dependabot
       require_relative "file_updater/podfile_updater"
       require_relative "file_updater/lockfile_updater"
 
-      WORD = /[a-zA-Z0-9\-_\.]+/.freeze
+      WORD = /[a-zA-Z0-9\-_\.\/]+/.freeze
       POD_NAME = /(('|")(?<q_name>#{WORD})('|")|(?<name>#{WORD}))/.freeze
 
       POD_VERSION = /((\d+)\.(\d+)\.(\*|\d+))/.freeze


### PR DESCRIPTION
Found out why the dryrun script wasn't succeeding for `RuudPuts/Down`

In that Podfile I've got a dependency with a subspec:
`pod 'XLActionController/Youtube', '~> 5.0.0'`
And the last pod in the file is
`pod 'SwiftHash', '~> 2.0.0'`


The `WORD` regex didn't match on the slash to be there which made the code fall back on the last pod in the file, SwiftHash, and tried to update that with version 5.0.2 (from XLActionController) which doesn't exist for SwiftHash.